### PR TITLE
separate "market gardener" from rocket jumper

### DIFF
--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_rocket_jumper/shared.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_rocket_jumper/shared.lua
@@ -19,14 +19,14 @@ if CLIENT then
 	SWEP.EquipMenuData = {
 		type = "item_weapon",
 		name = "Rocket Jumper",
-		desc = "LMB: Launch into the air\nLMB again: Melee another player while midair to CRIT",
+		desc = "LMB: Launch into the air\nCrowbar another player while midair to CRIT",
 	}
 
 	-- Path to the icon material
 	SWEP.Icon = "vgui/ttt/rocketjumper_icon.vtf"
 
 	SWEP.PrintName = "Rocket Jumper"
-	SWEP.Instructions = "LMB off the ground, melee another player while midair to CRIT"
+	SWEP.Instructions = "Switch to crowbar and melee another player while midair to CRIT"
 
 	SWEP.ViewModelFOV  = 65
 	SWEP.ViewModelFlip = false
@@ -34,10 +34,6 @@ if CLIENT then
 	SWEP.DrawAmmo = false
 	SWEP.DrawCrosshair = false
 end
-
-
-local VM_JUMPER = 0
-local VM_GARDEN = 1
 
 -- Always derive from weapon_tttbase.
 SWEP.Base				 = "weapon_tttbase"
@@ -47,37 +43,47 @@ SWEP.Base				 = "weapon_tttbase"
 SWEP.HoldType			 = "rpg"
 SWEP.HoldType1			 = "melee"
 
-SWEP.Primary.Delay       = 0.08
-SWEP.Primary.Automatic   = false
+SWEP.Primary.Delay       = 0.5
+SWEP.Primary.Automatic   = true
 SWEP.Primary.Ammo        = "none"
 SWEP.Primary.ClipSize    = -1
 SWEP.Primary.DefaultClip = -1
 
-SWEP.Primary.HitSound = Sound("Critical_Hit.mp3")
-SWEP.Primary.MissSound = Sound("Weapon_Crowbar.Single")
+SWEP.Primary.Sound = Sound("Weapon_Crossbow.Single")
+
+SWEP.DeploySpeed = 12
 
 SWEP.ViewModel  = "models/weapons/v_rpg.mdl"
-SWEP.ViewModel0  = "models/weapons/v_rpg.mdl"
-SWEP.ViewModel1  = "models/weapons/c_crowbar.mdl"
 SWEP.WorldModel = "models/weapons/w_rocket_launcher.mdl"
-SWEP.WorldModel0 = "models/weapons/w_rocket_launcher.mdl"
-SWEP.WorldModel1 = "models/weapons/w_crowbar.mdl"
 
-local shootSound = Sound( "Weapon_Crossbow.Single" )
+local ttt_rocket_jumper_crouched_mult = CreateConVar(
+	"ttt_rocket_jumper_crouched_mult", "1.5", FCVAR_ARCHIVE + FCVAR_NOTIFY + FCVAR_REPLICATED,
+	"set to 1.0 if you want knockback while crouched to be the same"
+)
 
---- Parameters
-local thrustSpeed = 1000
-local traceRange = 200
--- gardener:
-local hitboxRange = 120
-local damageValue = 1000
-local dropCheckInterval = 0.1
-local meleeSwingDelay = 0.05
-local swapSpeed = 4
-local deployUrgency = 100
-local gardenerExtents = 10
-local meleeForce = 5
-local deployLag = 3
+local ttt_rocket_jumper_bhop_window = CreateConVar(
+	"ttt_rocket_jumper_bhop_window", "0.1", FCVAR_ARCHIVE + FCVAR_NOTIFY + FCVAR_REPLICATED
+)
+
+local ttt_rocket_jumper_knockback_force = CreateConVar(
+	"ttt_rocket_jumper_knockback_force", "1000", FCVAR_ARCHIVE + FCVAR_NOTIFY + FCVAR_REPLICATED
+)
+
+local ttt_rocket_jumper_trace_distance = CreateConVar(
+	"ttt_rocket_jumper_trace_distance", "200", FCVAR_ARCHIVE + FCVAR_NOTIFY + FCVAR_REPLICATED
+)
+
+local ttt_rocket_jumper_melee_range = CreateConVar(
+	"ttt_rocket_jumper_melee_range", "120", FCVAR_ARCHIVE + FCVAR_NOTIFY + FCVAR_REPLICATED
+)
+
+local ttt_rocket_jumper_melee_damage = CreateConVar(
+	"ttt_rocket_jumper_melee_damage", "1000", FCVAR_ARCHIVE + FCVAR_NOTIFY + FCVAR_REPLICATED
+)
+
+local ttt_rocket_jumper_melee_delay = CreateConVar(
+	"ttt_rocket_jumper_melee_delay", "0.05", FCVAR_ARCHIVE + FCVAR_NOTIFY + FCVAR_REPLICATED
+)
 
 -- Make sure this is equal to their lua-filenames
 local jumperWeaponString = "weapon_ttt_rocket_jumper"
@@ -89,6 +95,7 @@ local jumperWeaponString = "weapon_ttt_rocket_jumper"
 -- each. Can be: WEAPON_... MELEE, PISTOL, HEAVY, NADE, CARRY, EQUIP1, EQUIP2 or ROLE.
 -- Matching SWEP.Slot values: 0      1       2     3      4      6       7        8
 SWEP.Kind = WEAPON_EQUIP1
+SWEP.Slot = 6
 
 -- If AutoSpawnable is true and SWEP.Kind is not WEAPON_EQUIP1/2, then this gun can
 -- be spawned as a random weapon.
@@ -125,7 +132,7 @@ SWEP.ShouldDropOnDie = true
 
 local function GetAimedAtVector(ply)
 	local worldShootPos = ply:GetShootPos()
-	local viewTargetPos = ply:GetAimVector() * traceRange
+	local viewTargetPos = ply:GetAimVector() * ttt_rocket_jumper_trace_distance:GetFloat()
 	local tr = util.TraceLine({
 		start = worldShootPos,
 		endpos = worldShootPos + viewTargetPos,
@@ -144,285 +151,251 @@ local function spawnExplosion(explosionLocation)
 	exp:Fire( "Explode", 0, 0 )
 end
 
-local function IsJumping(ply)
-	return IsValid(ply) and ply:IsPlayer() and ply:HasWeapon(jumperWeaponString)
-end
-
-function SWEP:SetupDataTables()
-	self:NetworkVar( "Bool", 0, "IsJumper" )
-
-	self:NetworkVarNotify( "IsJumper", self.JumperStateChange )
-end
-
--- it's easier to latch this on the netvar so the client doesn't
--- trip over prediction a boatload
-function SWEP:JumperStateChange( name, old, new )
-	if new ~= self.lastJumperState then
-		self.lastJumperState = new
-		if CLIENT then
-			if new then
-				self:BecomeJumper()
-			else
-				self:BecomeGardener()
-			end
+function SWEP:Initialize()
+	if CLIENT then
+		if self.AddHUDHelpLine then
+			self.HUDHelp = {
+				bindingLines = {},
+				maxLength = 0
+			}
+			self:AddHUDHelpLine(self.Instructions, Key("slot1", "undefined_key"))
+		else
+			self:AddHUDHelp(self.Instructions, nil, false)
 		end
 	end
+
+	return self.BaseClass.Initialize(self)
 end
 
-function SWEP:Initialize()
-	self:NextThink(CurTime() + dropCheckInterval)
-	self:SetIsJumper(true)
-	if CLIENT then
-		self:RefreshTTT2HUDHelp()
-	end
-end
-
-function SWEP:GetActiveViewModelIndex()
-	return not self:GetIsJumper() and VM_GARDEN or VM_JUMPER
-end
-
-function SWEP:Equip(ply)
-	ply:SelectWeapon(self:GetClass())
-end
-
--- jumper attack
 function SWEP:PrimaryAttack()
-	if self:GetIsJumper() then
-		self:JumperFire()
-	else
-		self:GardenerSwing()
+	local ply = self:GetOwner()
+
+	if not (IsValid(ply) and ply:IsPlayer()) then
+		return
 	end
+
+	ply:LagCompensation(true)
+	local worldTargetPos, isInRange = GetAimedAtVector(ply)
+	ply:LagCompensation(false)
+
+	if not isInRange then
+		return
+	end
+
+	local addvel = ply:GetAimVector()
+
+	addvel:Mul(-ttt_rocket_jumper_knockback_force:GetFloat())
+
+	-- +50% self-knockback while crouched like in tf2
+	if not ply:IsFlagSet(FL_DUCKING	+ FL_ANIMDUCKING) then
+		addvel:Div(ttt_rocket_jumper_crouched_mult:GetFloat())
+	end
+
+	ply:SetLocalVelocity(ply:GetVelocity() + addvel)
+
+	ply:RemoveFlags(FL_ONGROUND)
+
+	ply:SetAnimation(PLAYER_ATTACK1)
+
+	ply:SetNW2Float("ttt_rocket_jumper_groundedtime", 0)
+	ply:SetNW2Bool("ttt_rocket_jumper_isblastjumping", true)
+
+	if SERVER then
+		spawnExplosion(worldTargetPos)
+	end
+
+	self:EmitSound(self.Primary.Sound)
+
+	self:SetNextPrimaryFire(CurTime() + self.Primary.Delay)
+
+	self:SendWeaponAnim(ACT_VM_PRIMARYATTACK)
+end
+
+function SWEP:SecondaryAttack()
 end
 
 function SWEP:Reload()
-	if SERVER and not self:GetIsJumper() then
-		self:BecomeJumper()
-	end
-end
-
-function SWEP:JumperFire()
-	local ply = self:GetOwner()
-
-	local worldTargetPos, isInRange = GetAimedAtVector(ply)
-
-	if isInRange then
-		if SERVER then
-			ply:SetVelocity(-ply:GetAimVector() * thrustSpeed)
-
-			spawnExplosion(worldTargetPos)
-
-			self:EmitSound(shootSound)
-
-			self:BecomeGardener()
-		end
-
-		self:RemoveFlags( FL_ONGROUND )
-
-		self:SendWeaponAnim(ACT_RANGE_ATTACK_RPG, VM_JUMPER )
-		ply:SetAnimation(PLAYER_ATTACK1)
-		self:SetNextPrimaryFire( CurTime() + self:SequenceDuration() + 0.1)
-
-		local nextThink = CurTime() + dropCheckInterval
-		self:NextThink(nextThink)
-		if CLIENT then
-			self:SetNextClientThink(nextThink)
-		end
-	end
-end
-
-function SWEP:GardenerSwing()
-	local ply = self:GetOwner()
-
-	ply:LagCompensation(true)
-
-	local shootPos = ply:GetShootPos()
-	local endShootPos = (ply:GetAimVector() * hitboxRange) + shootPos
-	local tMin = Vector(1, 1, 1) * -gardenerExtents
-	local tMax = Vector(1, 1, 1) * gardenerExtents
-
-	local tr = util.TraceHull({
-		start = shootPos,
-		endpos = endShootPos,
-		filter = ply,
-		mask = MASK_SHOT_HULL,
-		mins = tMin,
-		maxs = tMax
-	})
-
-	if not IsValid(tr.Entity) then
-		tr = util.TraceLine({
-		start = shootPos,
-		endpos = endShootPos,
-		mask = MASK_SHOT_HULL,
-		filter = ply
-		})
-	end
-
-	local hitEnt = tr.Entity
-
-	if (IsValid(hitEnt) and (hitEnt:IsPlayer() or hitEnt:IsNPC())) then
-		self:SendViewModelAnim(ACT_VM_HITCENTER, VM_GARDEN)
-		ply:SetAnimation(PLAYER_ATTACK1)
-
-		if SERVER then
-			timer.Simple(meleeSwingDelay, function ()
-				local dmg = DamageInfo()
-				dmg:SetDamage(damageValue)
-				dmg:SetAttacker(ply)
-				if IsValid(self) then dmg:SetInflictor(self) end
-				dmg:SetDamageForce(ply:GetAimVector() * meleeForce)
-				dmg:SetDamagePosition(ply:GetPos())
-				dmg:SetDamageType(DMG_CLUB)
-
-				hitEnt:TakeDamageInfo(dmg)
-			end)
-		end
-		self:EmitSound(self.Primary.HitSound)
-
-	elseif not IsValid(hitEnt) then
-		self:SendViewModelAnim(ACT_VM_MISSCENTER, VM_GARDEN)
-		ply:SetAnimation(PLAYER_ATTACK1)
-
-		self:EmitSound(self.Primary.MissSound)
-	end
-	local delay = self:SequenceDuration()
-	self:SetNextPrimaryFire(CurTime() + delay + 0.1)
-
-	ply:LagCompensation(false)
-end
-
-function SWEP:BecomeGardener()
-	if SERVER then
-		self:SetIsJumper(false)
-	end
-
-	self:SetModel( self.WorldModel1 )
-	self.WorldModel = self.WorldModel1
-    -- lil hack to simulate jumper holster anim
-	self:SendViewModelAnim( ACT_VM_DRAW, VM_JUMPER, -swapSpeed)
-	self:SendViewModelAnim( ACT_VM_DRAW , VM_GARDEN, swapSpeed)
-	self:SetHoldType("melee")
-	if CLIENT then
-		self:RefreshTTT2HUDHelp()
-	end
-end
-
-function SWEP:BecomeJumper()
-	if SERVER then
-		self:SetIsJumper(true)
-	end
-
-	self:SetModel( self.WorldModel0 )
-	self.WorldModel = self.WorldModel0
-	self:SendViewModelAnim( ACT_VM_HOLSTER, VM_GARDEN, swapSpeed)
-	self:SendViewModelAnim( ACT_VM_DRAW, VM_JUMPER, swapSpeed)
-	self:SetHoldType("rpg")
-	if CLIENT then
-		self:RefreshTTT2HUDHelp()
-	end
 end
 
 function SWEP:Deploy()
-	if SERVER and not self:GetIsJumper() then
-		self:SetNextPrimaryFire(CurTime() + dropCheckInterval * deployLag)
-	end
-
 	local ply = self:GetOwner()
-	if not IsValid(ply) then return end
-	local vm1 = ply:GetViewModel( VM_GARDEN )
-	if ( IsValid( vm1 ) ) then
-		--associate its weapon to us
-		vm1:SetWeaponModel( self.ViewModel1, self )
-	end
 
-	if self:GetIsJumper() then
-		self:SendViewModelAnim( ACT_VM_HOLSTER, VM_GARDEN, swapSpeed * deployUrgency )
-	else
-		self:SendViewModelAnim( ACT_VM_DRAW, VM_JUMPER, -swapSpeed * deployUrgency )
+	if IsValid(ply) then
+		local vm = ply:GetViewModel()
+
+		if IsValid(vm) then
+			vm:SetPlaybackRate(2)
+		end
 	end
 
 	return true
 end
 
 function SWEP:Holster()
-	local ply = self:GetOwner()
-	if not IsValid(ply) then return end
-	local vm1 = ply:GetViewModel( VM_GARDEN )
-	if ( IsValid( vm1 ) ) then
-		--set its weapon to nil, this way the viewmodel won't show up again
-		vm1:SetWeaponModel( self.ViewModel1 , nil )
+	return true
+end
+
+local function blastjumpproxy(self, name, old, new)
+	return self:OnRocketJumperBlastJumpingUpdated(new)
+end
+
+if CLIENT then
+	hook.Add("InitPostEntity", "ttt_rocket_jumper_InitPostEntity", function()
+		LocalPlayer():SetNW2VarProxy("ttt_rocket_jumper_isblastjumping", blastjumpproxy)
+	end)
+else
+	hook.Add("PlayerInitialSpawn", "ttt_rocket_jumper_PlayerInitialSpawn", function(ply)
+		ply:SetNW2VarProxy("ttt_rocket_jumper_isblastjumping", blastjumpproxy)
+	end)
+end
+
+local Player = FindMetaTable("Player")
+
+local MarketGardenerNewPrimaryAttack
+
+function Player:OnRocketJumperBlastJumpingUpdated(isjumping)
+	local melee = self:GetWeapon("weapon_zm_improvised")
+
+	if not IsValid(melee) then
+		return
 	end
+
+	if isjumping then
+		melee:SetDeploySpeed(12)
+
+		if SERVER then
+			melee.MarketGardenerOldPrimaryAttack = melee.MarketGardenerOldPrimaryAttack or melee.PrimaryAttack
+			melee.PrimaryAttack = MarketGardenerNewPrimaryAttack
+		end
+	else
+		melee:SetDeploySpeed(melee.DeploySpeed or 1.5)
+
+		if SERVER and melee.MarketGardenerOldPrimaryAttack then
+			melee.PrimaryAttack = melee.MarketGardenerOldPrimaryAttack
+			melee.MarketGardenerOldPrimaryAttack = nil
+		end
+	end
+end
+
+hook.Add("PlayerPostThink", "ttt_rocket_jumper_PlayerPostThink", function(ply)
+	-- this lets people bhop to retain the market gardener crit like in tf2
+	
+	if not ply:GetNW2Bool("ttt_rocket_jumper_isblastjumping", false) then
+		return
+	end
+
+	local groundedtime = ply:GetNW2Float("ttt_rocket_jumper_groundedtime", 0)
+
+	if not (ply:OnGround() or ply:WaterLevel() ~= 0) then
+		if groundedtime ~= 0 then
+			ply:SetNW2Float("ttt_rocket_jumper_groundedtime", 0)
+		end
+
+		return
+	end
+
+	groundedtime = groundedtime + FrameTime()
+
+	if groundedtime > ttt_rocket_jumper_bhop_window:GetFloat() then
+		ply:SetNW2Float("ttt_rocket_jumper_groundedtime", 0)
+		ply:SetNW2Bool("ttt_rocket_jumper_isblastjumping", false)
+	else
+		ply:SetNW2Float("ttt_rocket_jumper_groundedtime", groundedtime)
+	end
+end)
+
+if CLIENT then
+	return
+end
+
+local function GardenerSwing(self)
+	local ply = self:GetOwner()
+
+	if not IsValid(ply) then
+		return
+	end
+
+	if not ply:GetNW2Bool("ttt_rocket_jumper_isblastjumping", false) then
+		return
+	end
+
+	ply:LagCompensation(true)
+
+	local shootPos = ply:GetShootPos()
+	local endShootPos = (ply:GetAimVector() * ttt_rocket_jumper_melee_range:GetFloat()) + shootPos
+
+	local tr = util.TraceLine({
+		start = shootPos,
+		endpos = endShootPos,
+		mask = MASK_SHOT_HULL,
+		filter = ply
+	})
+
+	if not IsValid(tr.Entity) then
+		tr = util.TraceHull({
+			start = shootPos,
+			endpos = endShootPos,
+			filter = ply,
+			mask = MASK_SHOT_HULL,
+			mins = Vector(-12, -12, -12),
+			maxs = Vector(12, 12, 12)
+		})
+	end
+
+	ply:LagCompensation(false)
+
+	local hitEnt = tr.Entity
+
+	if not (IsValid(hitEnt) and (hitEnt:IsPlayer() or hitEnt:IsNPC())) then
+		return
+	end
+
+	self:SendWeaponAnim(ACT_VM_HITCENTER)
+	ply:SetAnimation(PLAYER_ATTACK1)
+
+	timer.Simple(ttt_rocket_jumper_melee_delay:GetFloat(), function()
+		if not (IsValid(self) and IsValid(ply) and IsValid(hitEnt)) then
+			return
+		end
+
+		local wep = ply:GetWeapon("weapon_ttt_rocket_jumper")
+
+		if not IsValid(wep) then
+			wep = self
+		end
+
+		wep:EmitSound(Sound("Critical_Hit.mp3"))
+
+		if not (IsValid(ply) and IsValid(hitEnt)) then
+			return
+		end
+
+		local dmg = DamageInfo()
+		dmg:SetDamage(ttt_rocket_jumper_melee_damage:GetFloat())
+		dmg:SetAttacker(ply)
+		dmg:SetInflictor(wep)
+		dmg:SetDamageForce(ply:GetAimVector() * 5)
+		dmg:SetDamagePosition(ply:GetPos())
+		dmg:SetDamageType(DMG_CLUB)
+
+		hitEnt:TakeDamageInfo(dmg)
+	end)
+
+	self:SetNextPrimaryFire(CurTime() + self.Primary.Delay)
 
 	return true
 end
 
-function SWEP:SendViewModelAnim( act , index , rate )
-	if ( not game.SinglePlayer() and not IsFirstTimePredicted() ) then
+function MarketGardenerNewPrimaryAttack(self)
+	if GardenerSwing(self) then
 		return
 	end
 
-	local vm = self:GetOwner():GetViewModel( index )
-
-	if ( not IsValid( vm ) ) then
-		return
-	end
-
-	local seq = vm:SelectWeightedSequence( act )
-
-	if ( seq == -1 ) then
-		return
-	end
-
-	vm:SendViewModelMatchingSequence( seq )
-	vm:SetPlaybackRate( rate or 1 )
+	return self:MarketGardenerOldPrimaryAttack()
 end
 
-function SWEP:Think()
-	local ply = self:GetOwner()
-	if not self:GetIsJumper() then
-		if IsValid(ply) and (ply:OnGround() or ply:WaterLevel() ~= 0) then
-			if SERVER then
-				self:BecomeJumper()
-			end
-		else
-			local nextThink = CurTime() + dropCheckInterval
-			self:NextThink(nextThink)
-			if CLIENT then
-				self:SetNextClientThink(nextThink)
-			end
-		end
-	end
-end
-
-function SWEP:RefreshTTT2HUDHelp()
-	self.HUDHelp = {
-		bindingLines = {},
-		maxLength = 0
-	}
-
-	if not self:GetIsJumper() then
-		self:AddHUDHelpLine("rocket_jumper_primary", Key("+attack", "MOUSE1"))
-	else
-		self:AddHUDHelpLine("market_gardener_primary", Key("+attack", "MOUSE1"))
-		self:AddHUDHelpLine("market_gardener_cancel", Key("+reload", "R"))
-	end
-end
-
-hook.Add("OnPlayerHitGround", "market_gardener__DropMeleeOnFall", function(ply, inWater, onFloater, speed)
-	local wep = ply:GetActiveWeapon()
-	if SERVER and IsValid(wep) and wep:GetClass() == jumperWeaponString and (not wep:GetIsJumper()) and ply:IsPlayer() then
-		wep:BecomeJumper()
+hook.Add("EntityTakeDamage", "ttt_rocket_jumper_NoFallDamage", function(victim, dmginfo)
+	if victim:IsPlayer() and dmginfo:IsFallDamage() and victim:GetNW2Bool("ttt_rocket_jumper_isblastjumping", false) then
+		dmginfo:SetDamage(0)
 	end
 end)
-
-if SERVER then
-	-- rocket jumper logic
-	hook.Add("EntityTakeDamage", "rocket_jumper__NoFallDamage", function (target, dmgInfo)
-		local inflictor = dmgInfo:GetInflictor()
-
-		if (IsJumping(target) and dmgInfo:IsFallDamage())
-		or (IsJumping(inflictor) and dmgInfo:IsDamageType(DMG_CRUSH)) then
-			dmgInfo:SetDamage(0)
-		end
-	end)
-end

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_rocket_jumper/shared.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_rocket_jumper/shared.lua
@@ -190,7 +190,13 @@ function SWEP:PrimaryAttack()
 		addvel:Div(ttt_rocket_jumper_crouched_mult:GetFloat())
 	end
 
-	ply:SetLocalVelocity(ply:GetVelocity() + addvel)
+	local newvel = ply:GetVelocity() + addvel
+
+	ply:SetLocalVelocity(newvel)
+
+	if newvel.z > 1 then
+		ply:RemoveFlags(FL_ONGROUND)
+	end
 
 	ply:SetAnimation(PLAYER_ATTACK1)
 

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_rocket_jumper/shared.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_rocket_jumper/shared.lua
@@ -10,6 +10,7 @@ if SERVER then
 	AddCSLuaFile()
 
 	resource.AddFile("materials/vgui/ttt/rocketjumper_icon.vmt")
+	resource.AddFile("sound/Critical_Hit.mp3")
 end
 
 -- Equipment menu information is only needed on the client
@@ -81,12 +82,10 @@ local ttt_rocket_jumper_melee_damage = CreateConVar(
 	"ttt_rocket_jumper_melee_damage", "1000", FCVAR_ARCHIVE + FCVAR_NOTIFY + FCVAR_REPLICATED
 )
 
-local ttt_rocket_jumper_melee_delay = CreateConVar(
-	"ttt_rocket_jumper_melee_delay", "0.05", FCVAR_ARCHIVE + FCVAR_NOTIFY + FCVAR_REPLICATED
-)
 
 -- Make sure this is equal to their lua-filenames
 local jumperWeaponString = "weapon_ttt_rocket_jumper"
+local meleeWeaponString = "weapon_zm_improvised"
 
 
 --- TTT config values
@@ -158,7 +157,7 @@ function SWEP:Initialize()
 				bindingLines = {},
 				maxLength = 0
 			}
-			self:AddHUDHelpLine(self.Instructions, Key("slot1", "undefined_key"))
+			self:AddHUDHelpLine(self.Instructions, Key("+reload", "undefined_key"))
 		else
 			self:AddHUDHelp(self.Instructions, nil, false)
 		end
@@ -192,8 +191,6 @@ function SWEP:PrimaryAttack()
 	end
 
 	ply:SetLocalVelocity(ply:GetVelocity() + addvel)
-
-	ply:RemoveFlags(FL_ONGROUND)
 
 	ply:SetAnimation(PLAYER_ATTACK1)
 
@@ -235,6 +232,42 @@ function SWEP:Holster()
 	return true
 end
 
+if CLIENT then
+	hook.Add("CreateMove", "ttt_rocket_jumper_ReloadQuickSwitch", function(cmd)
+		local ply = LocalPlayer()
+
+		if not (IsValid(ply) and ply:KeyPressed(IN_RELOAD)) then
+			return
+		end
+
+		local oldwep = ply:GetActiveWeapon()
+
+		if not IsValid(oldwep) then
+			return
+		end
+
+		local oldclass = oldwep:GetClass()
+
+		local newclass = (
+			oldclass == jumperWeaponString and meleeWeaponString
+			or oldclass == meleeWeaponString and jumperWeaponString
+			or nil
+		)
+
+		if not newclass then
+			return
+		end
+
+		local newwep = ply:GetWeapon(newclass)
+
+		if not IsValid(newwep) then
+			return
+		end
+
+		cmd:SelectWeapon(newwep)
+	end)
+end
+
 local function blastjumpproxy(self, name, old, new)
 	return self:OnRocketJumperBlastJumpingUpdated(new)
 end
@@ -254,7 +287,7 @@ local Player = FindMetaTable("Player")
 local MarketGardenerNewPrimaryAttack
 
 function Player:OnRocketJumperBlastJumpingUpdated(isjumping)
-	local melee = self:GetWeapon("weapon_zm_improvised")
+	local melee = self:GetWeapon(meleeWeaponString)
 
 	if not IsValid(melee) then
 		return
@@ -279,7 +312,7 @@ end
 
 hook.Add("PlayerPostThink", "ttt_rocket_jumper_PlayerPostThink", function(ply)
 	-- this lets people bhop to retain the market gardener crit like in tf2
-	
+
 	if not ply:GetNW2Bool("ttt_rocket_jumper_isblastjumping", false) then
 		return
 	end
@@ -353,7 +386,7 @@ local function GardenerSwing(self)
 	self:SendWeaponAnim(ACT_VM_HITCENTER)
 	ply:SetAnimation(PLAYER_ATTACK1)
 
-	timer.Simple(ttt_rocket_jumper_melee_delay:GetFloat(), function()
+	timer.Simple(0.05, function()
 		if not (IsValid(self) and IsValid(ply) and IsValid(hitEnt)) then
 			return
 		end


### PR DESCRIPTION
supersedes #3

additional stuff from the mentioned pr:
-  separates the "market gardener" from the rocket jumper weapon entirely, so you can now crit with the base ttt crowbar instead (@EntranceJew's idea)
- adds a bunch of new cvars for tweaking the rocket jumper instead of just having local variables
